### PR TITLE
Fix severity counts in text report output

### DIFF
--- a/src/utils/formatters.py
+++ b/src/utils/formatters.py
@@ -149,12 +149,14 @@ class ReportFormatter:
         # Summary statistics
         lines.append("SUMMARY")
         lines.append("-" * 80)
+        # Normalize keys to handle lower-case severity counters
+        severity = {k.lower(): v for k, v in report_data.severity_stats.items()}
         lines.append(f"Total Findings: {len(report_data.findings)}")
-        lines.append(f"  Critical: {report_data.severity_stats.get('Critical', 0)}")
-        lines.append(f"  High: {report_data.severity_stats.get('High', 0)}")
-        lines.append(f"  Medium: {report_data.severity_stats.get('Medium', 0)}")
-        lines.append(f"  Low: {report_data.severity_stats.get('Low', 0)}")
-        lines.append(f"  Informational: {report_data.severity_stats.get('Informational', 0)}")
+        lines.append(f"  Critical: {severity.get('critical', 0)}")
+        lines.append(f"  High: {severity.get('high', 0)}")
+        lines.append(f"  Medium: {severity.get('medium', 0)}")
+        lines.append(f"  Low: {severity.get('low', 0)}")
+        lines.append(f"  Informational: {severity.get('info', 0)}")
         lines.append("")
 
         # Detailed findings


### PR DESCRIPTION
### **User description**
## Summary
- normalize severity statistic keys in text report generation
- ensure critical/high/medium/low/informational counts reflect calculated values

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69336d27f7d48332baa9f6be75337bc9)


___

### **PR Type**
Bug fix


___

### **Description**
- Normalize severity statistics keys to lowercase for consistent access

- Fix severity counter retrieval in text report generation

- Handle case-insensitive severity level lookups from report data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["severity_stats dict"] -- "normalize keys to lowercase" --> B["severity dict"]
  B -- "get critical/high/medium/low/info" --> C["formatted report output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>formatters.py</strong><dd><code>Normalize severity keys in text report</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/formatters.py

<ul><li>Added normalization of severity statistics keys to lowercase before <br>accessing<br> <li> Changed severity counter lookups from capitalized keys to lowercase <br>keys<br> <li> Updated 'Informational' key lookup to 'info' for consistency<br> <li> Ensures severity counts are correctly retrieved regardless of input <br>key casing</ul>


</details>


  </td>
  <td><a href="https://github.com/exrienz/ThreatCode/pull/2/files#diff-ce4d75c0bcb07728c821623e9d544746cef0ce63115ad4738874f32d5df5a73d">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

